### PR TITLE
Use new Astral 2.2 (only python 3)

### DIFF
--- a/gw2pvo/__main__.py
+++ b/gw2pvo/__main__.py
@@ -6,7 +6,9 @@ import argparse
 import locale
 import time
 from datetime import datetime
-from astral import Astral
+from astral import LocationInfo
+from astral.geocoder import lookup, database
+from astral.location import Location
 from gw2pvo import ds_api
 from gw2pvo import gw_api
 from gw2pvo import gw_csv
@@ -25,10 +27,9 @@ def run_once(args):
 
     # Check if we only want to run during daylight
     if args.city:
-        a = Astral()
-        sun = a[args.city].sun(local=True)
+        l = Location(lookup(args.city, database()))
         now = datetime.time(datetime.now())
-        if now < sun['dawn'].time() or now > sun['dusk'].time():
+        if now < l.dawn().time() or now > l.dusk().time():
             logging.debug("Skipped upload as it's night")
             return
 


### PR DESCRIPTION
Building with astral did not work as python was resolving to Astral 2.2 which has changed it's API.
(See also #37)
This only works with Python 3.

That's why I separated it from the login change (#42)